### PR TITLE
Formatting typos

### DIFF
--- a/Instructions/Labs/dp900-02-storage-lab.md
+++ b/Instructions/Labs/dp900-02-storage-lab.md
@@ -44,7 +44,7 @@ Now that you have an Azure Storage account, you can create a container for blob 
 1. In the Azure portal page for your storage container, on the left side, in the **Data storage** section, select **Containers**.
 1. In the **Containers** page, select **&#65291; Container** and add a new container named **data** with a public access level of **Private (no anonymous access)**.
 1. When the **data** container has been created, verify that it's listed in the **Containers** page.
-1. In the pane on the left side, in the top section, select **Storage browser **. This page provides a browser-based interface that you can use to work with the data in your storage account.
+1. In the pane on the left side, in the top section, select **Storage browser**. This page provides a browser-based interface that you can use to work with the data in your storage account.
 1. In the storage browser page, select **Blob containers** and verify that your **data** container is listed.
 1. Select the **data** container, and note that it's empty.
 1. Select **&#65291; Add Directory** and read the information about folders before creating a new directory named **products**.
@@ -68,7 +68,7 @@ Azure Data Lake Store Gen2 support enables you to use hierarchical folders to or
 
 1. Download the [product2.json](https://aka.ms/product2.json?azure-portal=true) JSON file from `https://aka.ms/product2.json` and save it on your computer in the same folder where you downloaded **product1.json** previously - you'll upload it to blob storage later).
 1. In the Azure portal page for your storage account, on the left side, scroll down to the **Settings** section, and select **Data Lake Gen2 upgrade**.
-1. In the ****Data Lake Gen2 upgrade**** page, expand and complete each step to upgrade your storage account to enable hierarchical namespace and support Azure Data Lake Storage Gen 2. This may take some time.
+1. In the **Data Lake Gen2 upgrade** page, expand and complete each step to upgrade your storage account to enable hierarchical namespace and support Azure Data Lake Storage Gen 2. This may take some time.
 1. When the upgrade is complete, in the pane on the left side, in the top section, select **Storage browser** and navigate back to the root of your **data** blob container, which still contains the **product_data** folder.
 1. Select the **product_data** folder, and verify it still contains the **product1.json** file you uploaded previously.
 1. Use the **&#10514; Upload** button to open the **Upload blob** panel.


### PR DESCRIPTION
Removed extra space, rendering asterisks instead of bolding in markdown. Also removed "double bolding" rending as bolded asterisks.
